### PR TITLE
T01: document upload + version metadata

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "fastapi>=0.116.0",
   "uvicorn[standard]>=0.35.0",
   "pydantic>=2.11.0",
+  "python-multipart>=0.0.9",
 ]
 
 [project.optional-dependencies]

--- a/backend/sql/schema.sql
+++ b/backend/sql/schema.sql
@@ -1,9 +1,16 @@
 CREATE TABLE IF NOT EXISTS documents (
     id TEXT PRIMARY KEY,
+    doc_key TEXT NOT NULL,
     version TEXT NOT NULL,
     filename TEXT NOT NULL,
+    content_type TEXT NOT NULL,
+    size_bytes INTEGER NOT NULL,
+    storage_path TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_documents_doc_key_version
+ON documents(doc_key, version);
 
 CREATE TABLE IF NOT EXISTS project_config (
     id INTEGER PRIMARY KEY CHECK (id = 1),

--- a/backend/src/app/api/router.py
+++ b/backend/src/app/api/router.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 
-from app.api.routes import references
+from app.api.routes import documents, references
 
 api_router = APIRouter(prefix="/api/v1")
+api_router.include_router(documents.router, prefix="/documents", tags=["documents"])
 api_router.include_router(references.router, prefix="/references", tags=["references"])

--- a/backend/src/app/api/routes/documents.py
+++ b/backend/src/app/api/routes/documents.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from shutil import copyfileobj
+from uuid import UUID, uuid4
+
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+from pydantic import BaseModel
+
+from app.core.db import get_connection, get_data_dir
+
+router = APIRouter()
+
+
+class DocumentRead(BaseModel):
+    id: UUID
+    doc_key: str
+    version: str
+    filename: str
+    content_type: str
+    size_bytes: int
+    created_at: datetime
+
+
+def _safe_segment(value: str) -> str:
+    return "".join(ch if ch.isalnum() or ch in {"-", "_", "."} else "_" for ch in value)
+
+
+def _uploads_dir() -> Path:
+    path = get_data_dir() / "uploads"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _row_to_document(row: sqlite3.Row) -> DocumentRead:
+    return DocumentRead(
+        id=UUID(row["id"]),
+        doc_key=row["doc_key"],
+        version=row["version"],
+        filename=row["filename"],
+        content_type=row["content_type"],
+        size_bytes=row["size_bytes"],
+        created_at=row["created_at"],
+    )
+
+
+@router.post("", response_model=DocumentRead)
+def upload_document(
+    doc_key: str = Form(...),
+    version: str = Form(...),
+    file: UploadFile = File(...),
+) -> DocumentRead:
+    clean_doc_key = doc_key.strip()
+    clean_version = version.strip()
+    if not clean_doc_key or not clean_version:
+        raise HTTPException(status_code=422, detail="doc_key and version are required")
+
+    if not file.filename:
+        raise HTTPException(status_code=422, detail="file name is required")
+
+    doc_id = uuid4()
+    safe_name = _safe_segment(file.filename)
+    target_dir = _uploads_dir() / _safe_segment(clean_doc_key)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_path = target_dir / f"{_safe_segment(clean_version)}_{doc_id}_{safe_name}"
+
+    with target_path.open("wb") as out:
+        copyfileobj(file.file, out)
+    size_bytes = target_path.stat().st_size
+
+    try:
+        with get_connection() as conn:
+            conn.execute(
+                """
+                INSERT INTO documents (
+                    id, doc_key, version, filename, content_type, size_bytes, storage_path
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    str(doc_id),
+                    clean_doc_key,
+                    clean_version,
+                    file.filename,
+                    file.content_type or "application/octet-stream",
+                    size_bytes,
+                    str(target_path),
+                ),
+            )
+            row = conn.execute(
+                """
+                SELECT id, doc_key, version, filename, content_type, size_bytes, created_at
+                FROM documents
+                WHERE id = ?
+                """,
+                (str(doc_id),),
+            ).fetchone()
+    except sqlite3.IntegrityError:
+        target_path.unlink(missing_ok=True)
+        raise HTTPException(
+            status_code=409, detail=f"Version already exists for doc_key '{clean_doc_key}'"
+        ) from None
+
+    return _row_to_document(row)
+
+
+@router.get("/{document_id}", response_model=DocumentRead)
+def get_document(document_id: UUID) -> DocumentRead:
+    with get_connection() as conn:
+        row = conn.execute(
+            """
+            SELECT id, doc_key, version, filename, content_type, size_bytes, created_at
+            FROM documents
+            WHERE id = ?
+            """,
+            (str(document_id),),
+        ).fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Document not found")
+    return _row_to_document(row)
+
+
+@router.get("/{doc_key}/versions", response_model=list[DocumentRead])
+def list_document_versions(doc_key: str) -> list[DocumentRead]:
+    with get_connection() as conn:
+        rows = conn.execute(
+            """
+            SELECT id, doc_key, version, filename, content_type, size_bytes, created_at
+            FROM documents
+            WHERE doc_key = ?
+            ORDER BY created_at DESC
+            """,
+            (doc_key,),
+        ).fetchall()
+    return [_row_to_document(row) for row in rows]

--- a/backend/src/app/core/db.py
+++ b/backend/src/app/core/db.py
@@ -8,6 +8,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[3]
 SCHEMA_PATH = PROJECT_ROOT / "sql" / "schema.sql"
 DEFAULT_DB_PATH = PROJECT_ROOT / "data" / "cluster_test_mgmt.db"
 DB_PATH_ENV = "CTM_DB_PATH"
+DATA_DIR_ENV = "CTM_DATA_DIR"
 
 
 def get_db_path() -> Path:
@@ -17,6 +18,13 @@ def get_db_path() -> Path:
     return DEFAULT_DB_PATH
 
 
+def get_data_dir() -> Path:
+    raw = os.getenv(DATA_DIR_ENV)
+    if raw:
+        return Path(raw).expanduser().resolve()
+    return DEFAULT_DB_PATH.parent
+
+
 def _connect(db_path: Path) -> sqlite3.Connection:
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
@@ -24,12 +32,33 @@ def _connect(db_path: Path) -> sqlite3.Connection:
     return conn
 
 
+def _apply_runtime_migrations(conn: sqlite3.Connection) -> None:
+    columns = {
+        row["name"] for row in conn.execute("PRAGMA table_info(documents)").fetchall()
+    }
+    if "doc_key" not in columns:
+        conn.execute("ALTER TABLE documents ADD COLUMN doc_key TEXT NOT NULL DEFAULT ''")
+    if "content_type" not in columns:
+        conn.execute("ALTER TABLE documents ADD COLUMN content_type TEXT NOT NULL DEFAULT ''")
+    if "size_bytes" not in columns:
+        conn.execute("ALTER TABLE documents ADD COLUMN size_bytes INTEGER NOT NULL DEFAULT 0")
+    if "storage_path" not in columns:
+        conn.execute("ALTER TABLE documents ADD COLUMN storage_path TEXT NOT NULL DEFAULT ''")
+    conn.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_documents_doc_key_version
+        ON documents(doc_key, version)
+        """
+    )
+
+
 def init_db() -> Path:
     db_path = get_db_path()
-    db_path.parent.mkdir(parents=True, exist_ok=True)
+    get_data_dir().mkdir(parents=True, exist_ok=True)
     schema_sql = SCHEMA_PATH.read_text(encoding="utf-8")
     with _connect(db_path) as conn:
         conn.executescript(schema_sql)
+        _apply_runtime_migrations(conn)
     return db_path
 
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -5,6 +5,8 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def isolated_db_path(monkeypatch: pytest.MonkeyPatch, tmp_path) -> Generator[None, None, None]:
-    db_path = tmp_path / "test.db"
+    data_dir = tmp_path / "data"
+    db_path = data_dir / "test.db"
     monkeypatch.setenv("CTM_DB_PATH", str(db_path))
+    monkeypatch.setenv("CTM_DATA_DIR", str(data_dir))
     yield

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -1,0 +1,50 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_upload_get_and_list_versions() -> None:
+    client = TestClient(app)
+    payload = {"doc_key": "backlight-spec", "version": "v1"}
+    files = {
+        "file": (
+            "backlight.xlsx",
+            b"binary-content",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
+    }
+
+    create_resp = client.post("/api/v1/documents", data=payload, files=files)
+    assert create_resp.status_code == 200
+    created = create_resp.json()
+    assert created["doc_key"] == "backlight-spec"
+    assert created["version"] == "v1"
+    assert created["filename"] == "backlight.xlsx"
+    assert created["size_bytes"] == len(b"binary-content")
+
+    get_resp = client.get(f"/api/v1/documents/{created['id']}")
+    assert get_resp.status_code == 200
+    assert get_resp.json()["id"] == created["id"]
+
+    versions_resp = client.get("/api/v1/documents/backlight-spec/versions")
+    assert versions_resp.status_code == 200
+    versions = versions_resp.json()
+    assert len(versions) == 1
+    assert versions[0]["version"] == "v1"
+
+
+def test_upload_duplicate_version_returns_409() -> None:
+    client = TestClient(app)
+    payload = {"doc_key": "backlight-spec", "version": "v2"}
+    files = {
+        "file": (
+            "backlight.xlsx",
+            b"a",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
+    }
+    first = client.post("/api/v1/documents", data=payload, files=files)
+    assert first.status_code == 200
+
+    second = client.post("/api/v1/documents", data=payload, files=files)
+    assert second.status_code == 409


### PR DESCRIPTION
Implements document upload and versioned metadata persistence.\n\nWhat changed:\n- Added /api/v1/documents upload endpoint (multipart file + doc_key + version)\n- Added metadata retrieval by document id\n- Added version listing by doc_key\n- Enforced unique (doc_key, version) with 409 on duplicate version\n- Added tests for upload, retrieval, version list, duplicate handling\n\nValidation:\n- pytest: 6 passed\n- ruff check: passed\n\nCloses #2