### PR TITLE
T02: reference model + API hardening

### DIFF
--- a/backend/sql/schema.sql
+++ b/backend/sql/schema.sql
@@ -28,6 +28,9 @@ CREATE TABLE IF NOT EXISTS "references" (
     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE INDEX IF NOT EXISTS idx_references_doc_id
+ON "references"(doc_id);
+
 CREATE TABLE IF NOT EXISTS requirements (
     id TEXT PRIMARY KEY,
     statement TEXT NOT NULL,

--- a/backend/src/app/api/routes/references.py
+++ b/backend/src/app/api/routes/references.py
@@ -1,7 +1,8 @@
+from datetime import datetime
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.core.db import get_connection
 
@@ -9,27 +10,43 @@ router = APIRouter()
 
 
 class ReferenceCreate(BaseModel):
-    doc_id: str
-    location: str
-    excerpt: str
+    doc_id: UUID
+    location: str = Field(min_length=1)
+    excerpt: str = Field(min_length=1)
 
 
 class ReferenceRead(ReferenceCreate):
     id: UUID
+    created_at: datetime
 
 
 @router.post("", response_model=ReferenceRead)
 def create_reference(payload: ReferenceCreate) -> ReferenceRead:
-    ref = ReferenceRead(id=uuid4(), **payload.model_dump())
     with get_connection() as conn:
+        doc_exists = conn.execute(
+            "SELECT 1 FROM documents WHERE id = ?",
+            (str(payload.doc_id),),
+        ).fetchone()
+        if doc_exists is None:
+            raise HTTPException(status_code=404, detail="Document not found")
+
+        reference_id = uuid4()
         conn.execute(
             """
             INSERT INTO "references" (id, doc_id, location, excerpt)
             VALUES (?, ?, ?, ?)
             """,
-            (str(ref.id), ref.doc_id, ref.location, ref.excerpt),
+            (str(reference_id), str(payload.doc_id), payload.location, payload.excerpt),
         )
-    return ref
+        row = conn.execute(
+            """
+            SELECT id, doc_id, location, excerpt, created_at
+            FROM "references"
+            WHERE id = ?
+            """,
+            (str(reference_id),),
+        ).fetchone()
+    return _to_reference_read(row)
 
 
 @router.get("/{reference_id}", response_model=ReferenceRead)
@@ -37,7 +54,7 @@ def get_reference(reference_id: UUID) -> ReferenceRead:
     with get_connection() as conn:
         row = conn.execute(
             """
-            SELECT id, doc_id, location, excerpt
+            SELECT id, doc_id, location, excerpt, created_at
             FROM "references"
             WHERE id = ?
             """,
@@ -47,9 +64,14 @@ def get_reference(reference_id: UUID) -> ReferenceRead:
     if row is None:
         raise HTTPException(status_code=404, detail="Reference not found")
 
+    return _to_reference_read(row)
+
+
+def _to_reference_read(row) -> ReferenceRead:
     return ReferenceRead(
         id=UUID(row["id"]),
-        doc_id=row["doc_id"],
+        doc_id=UUID(row["doc_id"]),
         location=row["location"],
         excerpt=row["excerpt"],
+        created_at=row["created_at"],
     )

--- a/backend/tests/test_references.py
+++ b/backend/tests/test_references.py
@@ -3,10 +3,25 @@ from fastapi.testclient import TestClient
 from app.main import app
 
 
+def _create_document(client: TestClient) -> str:
+    payload = {"doc_key": "backlight-spec", "version": "v-ref"}
+    files = {
+        "file": (
+            "reference-source.xlsx",
+            b"sheet-content",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
+    }
+    response = client.post("/api/v1/documents", data=payload, files=files)
+    assert response.status_code == 200
+    return response.json()["id"]
+
+
 def test_create_and_get_reference() -> None:
     client = TestClient(app)
+    doc_id = _create_document(client)
     payload = {
-        "doc_id": "doc-1",
+        "doc_id": doc_id,
         "location": "sheet:Backlight!A2",
         "excerpt": "Level 1 -> 500 nits",
     }
@@ -14,13 +29,26 @@ def test_create_and_get_reference() -> None:
     create_resp = client.post("/api/v1/references", json=payload)
     assert create_resp.status_code == 200
     created = create_resp.json()
+    assert created["doc_id"] == doc_id
+    assert "created_at" in created
 
     get_resp = client.get(f"/api/v1/references/{created['id']}")
     assert get_resp.status_code == 200
-    assert get_resp.json()["doc_id"] == "doc-1"
+    assert get_resp.json()["doc_id"] == doc_id
 
 
 def test_get_missing_reference_returns_404() -> None:
     client = TestClient(app)
     response = client.get("/api/v1/references/11111111-1111-1111-1111-111111111111")
+    assert response.status_code == 404
+
+
+def test_create_reference_requires_existing_document() -> None:
+    client = TestClient(app)
+    payload = {
+        "doc_id": "11111111-1111-1111-1111-111111111111",
+        "location": "sheet:Backlight!A2",
+        "excerpt": "Level 1 -> 500 nits",
+    }
+    response = client.post("/api/v1/references", json=payload)
     assert response.status_code == 404


### PR DESCRIPTION
Implements T02 Reference model and API improvements.\n\nChanges:\n- Reference payload now uses UUID doc_id\n- Validate referenced document exists before insert\n- Return created_at in create/get responses\n- Added index on references.doc_id\n- Added tests for document-backed reference creation and missing-document rejection\n\nValidation:\n- pytest: 7 passed\n- ruff check: passed\n\nCloses #3