### PR TITLE
T03: Excel parser v1 (merge expansion + row refs)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -9,6 +9,7 @@ description = "Backend service for cluster test management"
 requires-python = ">=3.12"
 dependencies = [
   "fastapi>=0.116.0",
+  "openpyxl>=3.1.0",
   "uvicorn[standard]>=0.35.0",
   "pydantic>=2.11.0",
   "python-multipart>=0.0.9",

--- a/backend/src/app/parsing/__init__.py
+++ b/backend/src/app/parsing/__init__.py
@@ -1,0 +1,15 @@
+from app.parsing.excel import (
+    ParsedCell,
+    ParsedReference,
+    ParsedRow,
+    parse_excel_bytes,
+    parse_excel_file,
+)
+
+__all__ = [
+    "ParsedCell",
+    "ParsedReference",
+    "ParsedRow",
+    "parse_excel_bytes",
+    "parse_excel_file",
+]

--- a/backend/src/app/parsing/excel.py
+++ b/backend/src/app/parsing/excel.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
+
+from openpyxl import load_workbook
+from openpyxl.utils import get_column_letter
+from openpyxl.worksheet.worksheet import Worksheet
+
+
+@dataclass(frozen=True)
+class ParsedCell:
+    coordinate: str
+    source_coordinate: str
+    value: str
+
+
+@dataclass(frozen=True)
+class ParsedReference:
+    doc_id: str
+    location: str
+    excerpt: str
+
+
+@dataclass(frozen=True)
+class ParsedRow:
+    sheet_name: str
+    row_index: int
+    cells: list[ParsedCell]
+    reference: ParsedReference
+
+
+def parse_excel_bytes(*, file_bytes: bytes, doc_id: str) -> list[ParsedRow]:
+    workbook = load_workbook(filename=BytesIO(file_bytes), data_only=True)
+    parsed_rows: list[ParsedRow] = []
+
+    for sheet in workbook.worksheets:
+        merged_source_map = _expand_merged_cells(sheet)
+        parsed_rows.extend(
+            _extract_sheet_rows(
+                sheet=sheet,
+                merged_source_map=merged_source_map,
+                doc_id=doc_id,
+            )
+        )
+
+    return parsed_rows
+
+
+def parse_excel_file(*, file_path: str | Path, doc_id: str) -> list[ParsedRow]:
+    raw = Path(file_path).read_bytes()
+    return parse_excel_bytes(file_bytes=raw, doc_id=doc_id)
+
+
+def _extract_sheet_rows(
+    *, sheet: Worksheet, merged_source_map: dict[str, str], doc_id: str
+) -> list[ParsedRow]:
+    rows: list[ParsedRow] = []
+    for row_index in range(1, sheet.max_row + 1):
+        cells: list[ParsedCell] = []
+        for col_index in range(1, sheet.max_column + 1):
+            coord = f"{get_column_letter(col_index)}{row_index}"
+            value = sheet.cell(row=row_index, column=col_index).value
+            if value is None:
+                continue
+
+            normalized = _normalize_value(value)
+            cells.append(
+                ParsedCell(
+                    coordinate=coord,
+                    source_coordinate=merged_source_map.get(coord, coord),
+                    value=normalized,
+                )
+            )
+
+        if not cells:
+            continue
+
+        excerpt = " | ".join(f"{cell.coordinate}={cell.value}" for cell in cells)
+        rows.append(
+            ParsedRow(
+                sheet_name=sheet.title,
+                row_index=row_index,
+                cells=cells,
+                reference=ParsedReference(
+                    doc_id=doc_id,
+                    location=f"sheet:{sheet.title}!row:{row_index}",
+                    excerpt=excerpt,
+                ),
+            )
+        )
+    return rows
+
+
+def _expand_merged_cells(sheet: Worksheet) -> dict[str, str]:
+    source_map: dict[str, str] = {}
+    merged_ranges = list(sheet.merged_cells.ranges)
+    for merged_range in merged_ranges:
+        min_col, min_row, max_col, max_row = merged_range.bounds
+        source_coord = f"{get_column_letter(min_col)}{min_row}"
+        source_value = sheet.cell(row=min_row, column=min_col).value
+
+        sheet.unmerge_cells(str(merged_range))
+        for row in range(min_row, max_row + 1):
+            for col in range(min_col, max_col + 1):
+                coord = f"{get_column_letter(col)}{row}"
+                sheet.cell(row=row, column=col, value=source_value)
+                source_map[coord] = source_coord
+
+    return source_map
+
+
+def _normalize_value(value: object) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    return str(value)

--- a/backend/tests/test_excel_parser.py
+++ b/backend/tests/test_excel_parser.py
@@ -1,0 +1,61 @@
+from io import BytesIO
+
+from openpyxl import Workbook
+
+from app.parsing.excel import parse_excel_bytes
+
+
+def _build_workbook_bytes() -> bytes:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Backlight"
+
+    ws["A1"] = "Level"
+    ws.merge_cells("A1:B1")
+    ws["A2"] = "L1"
+    ws["B2"] = 500
+    ws["A3"] = "Group-A"
+    ws.merge_cells("A3:A4")
+    ws["B4"] = "tail"
+
+    raw = BytesIO()
+    wb.save(raw)
+    return raw.getvalue()
+
+
+def test_parse_excel_expands_merged_cells_and_emits_references() -> None:
+    rows = parse_excel_bytes(file_bytes=_build_workbook_bytes(), doc_id="doc-123")
+
+    assert len(rows) == 4
+
+    row1 = rows[0]
+    assert row1.sheet_name == "Backlight"
+    assert row1.row_index == 1
+    assert row1.reference.doc_id == "doc-123"
+    assert row1.reference.location == "sheet:Backlight!row:1"
+    assert row1.reference.excerpt == "A1=Level | B1=Level"
+    assert row1.cells[0].coordinate == "A1"
+    assert row1.cells[0].source_coordinate == "A1"
+    assert row1.cells[1].coordinate == "B1"
+    assert row1.cells[1].source_coordinate == "A1"
+
+    row4 = rows[3]
+    assert row4.row_index == 4
+    assert row4.reference.location == "sheet:Backlight!row:4"
+    assert row4.cells[0].coordinate == "A4"
+    assert row4.cells[0].source_coordinate == "A3"
+    assert row4.cells[0].value == "Group-A"
+
+
+def test_parse_excel_skips_empty_rows() -> None:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Sheet1"
+    ws["A1"] = "x"
+    ws["A3"] = "y"
+
+    raw = BytesIO()
+    wb.save(raw)
+    rows = parse_excel_bytes(file_bytes=raw.getvalue(), doc_id="doc-1")
+
+    assert [row.row_index for row in rows] == [1, 3]


### PR DESCRIPTION
Implements Excel parsing v1 with deterministic merge expansion, row extraction, and row-level references.

Changes:
- Added parser module in app.parsing.excel
- Expands merged ranges before extraction
- Preserves source coordinates for each extracted cell
- Emits row-level reference (doc_id, location, excerpt)
- Added parser unit tests for merge expansion, row extraction, and empty-row skipping
- Added openpyxl dependency

Validation:
- pytest: 9 passed
- ruff check: passed

Closes #4